### PR TITLE
修复个小问题：IE11点击保存为图片，鼠标移到图片上提示“点击保存”，但是没有反应

### DIFF
--- a/src/component/toolbox.js
+++ b/src/component/toolbox.js
@@ -811,8 +811,7 @@ define(function (require) {
             );
             downloadLink.innerHTML = '<img style="vertical-align:middle" src="' + image 
                 + '" title="'
-                + (!!(window.attachEvent 
-                     && navigator.userAgent.indexOf('Opera') === -1)
+                + ((!!window.ActiveXObject || "ActiveXObject" in window)
                   ? '右键->图片另存为'
                   : (saveOption.lang ? saveOption.lang[0] : '点击保存'))
                 + '"/>';


### PR DESCRIPTION
1. IE11不支持<a> download 属性；
2. IE11不能通过window.attachEvent判断了。