### PR TITLE
remove tooltips issue

### DIFF
--- a/src/component/tooltip.js
+++ b/src/component/tooltip.js
@@ -1706,7 +1706,7 @@ define(function (require) {
             this.zr.un(zrConfig.EVENT.MOUSEMOVE, this._onmousemove);
             this.zr.un(zrConfig.EVENT.GLOBALOUT, this._onglobalout);
             
-            if (this.hasAppend) {
+            if (this.hasAppend && !!this.dom.firstChild) {
                 this.dom.firstChild.removeChild(this._tDom);
             }
             this._tDom = null;


### PR DESCRIPTION
同一dom上多次init图表时出现的问题。这个问题在正确使用echarts时并不会出现，此次提交是希望提高echarts的容错能力。
具体问题是：我们在项目中使用带有tooltips的柱状图。如果第一次生成的实例中鼠标hover过（append了tooltips），然而在销毁实例时没有使用dispose方法正确销毁（比如直接将该dom的innerHTML=''）。
那第二次在此dom生成实例时，echarts会自动释放上一个实例。这时由于dom已为空（因为innerHTML设置为''），而echarts还会尝试移除tooltips，导致页面出错，无法生成新的实例。