### PR TITLE
修复IE10, 11下的一系列脚本报错

### DIFF
--- a/src/component/dataView.js
+++ b/src/component/dataView.js
@@ -36,7 +36,7 @@ define(function (require) {
     
         this._tDom.className = 'echarts-dataview';
         this.hide();
-        this.dom.firstChild.appendChild(this._tDom);
+        this.dom.children[0].appendChild(this._tDom);
 
         if (window.addEventListener) {
             this._tDom.addEventListener('click', this._stop);
@@ -443,7 +443,7 @@ define(function (require) {
             this._buttonRefresh = null;
             this._buttonClose = null;
 
-            this.dom.firstChild.removeChild(this._tDom);
+            this.dom.children[0].removeChild(this._tDom);
             this._tDom = null;
         }
     };

--- a/src/component/tooltip.js
+++ b/src/component/tooltip.js
@@ -761,7 +761,7 @@ define(function (require) {
                 if (!this.hasAppend) {
                     this._tDom.style.left = this._zrWidth / 2 + 'px';
                     this._tDom.style.top = this._zrHeight / 2 + 'px';
-                    this.dom.firstChild.appendChild(this._tDom);
+                    this.dom.children[0].appendChild(this._tDom);
                     this.hasAppend = true;
                 }
                 this._show(position, x + 10, y + 10, specialCssText);
@@ -913,7 +913,7 @@ define(function (require) {
                 if (!this.hasAppend) {
                     this._tDom.style.left = this._zrWidth / 2 + 'px';
                     this._tDom.style.top = this._zrHeight / 2 + 'px';
-                    this.dom.firstChild.appendChild(this._tDom);
+                    this.dom.children[0].appendChild(this._tDom);
                     this.hasAppend = true;
                 }
                 this._show(
@@ -1085,7 +1085,7 @@ define(function (require) {
             if (!this.hasAppend) {
                 this._tDom.style.left = this._zrWidth / 2 + 'px';
                 this._tDom.style.top = this._zrHeight / 2 + 'px';
-                this.dom.firstChild.appendChild(this._tDom);
+                this.dom.children[0].appendChild(this._tDom);
                 this.hasAppend = true;
             }
             
@@ -1748,8 +1748,8 @@ define(function (require) {
             this.zr.un(zrConfig.EVENT.MOUSEMOVE, this._onmousemove);
             this.zr.un(zrConfig.EVENT.GLOBALOUT, this._onglobalout);
             
-            if (this.hasAppend && !!this.dom.firstChild) {
-                this.dom.firstChild.removeChild(this._tDom);
+            if (this.hasAppend && !!this.dom.children[0]) {
+                this.dom.children[0].removeChild(this._tDom);
             }
             this._tDom = null;
         },

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -786,7 +786,7 @@ define(function (require) {
                     img.style.position = 'absolute';
                     img.style.left = 0;
                     img.style.top = 0;
-                    this.dom.firstChild.appendChild(img);
+                    this.dom.children[0].appendChild(img);
                 }
                 this.un();
                 this._zr.un();

--- a/src/util/projection/svg.js
+++ b/src/util/projection/svg.js
@@ -14,7 +14,7 @@ define(function(require) {
     }
 
     function getBbox(root) {
-        var svgNode = root.firstChild;
+        var svgNode = root.children[0];
         // Find the svg node
         while (!(svgNode.nodeName.toLowerCase() == 'svg' && svgNode.nodeType == 1)) {
             svgNode = svgNode.nextSibling;


### PR DESCRIPTION
IE10,11下dom.firstChild会取到空的文本节点, 从而导致报错