### PR TITLE
图表从有数据到无数据无法绘制。

### DIFF
--- a/src/component/dataZoom.js
+++ b/src/component/dataZoom.js
@@ -299,7 +299,7 @@ define(function (require) {
                 serie = series[seriesIndex[i]];
                 this._originalData.series[seriesIndex[i]] = serie.data;
                 if (serie.data
-                    && (serie.data.lengh ===0 || this.getDataFromOption(serie.data[0]) instanceof Array)
+                    && (serie.data.length === 0 || this.getDataFromOption(serie.data[0]) instanceof Array)
                     && (serie.type == ecConfig.CHART_TYPE_SCATTER
                         || serie.type == ecConfig.CHART_TYPE_LINE
                         || serie.type == ecConfig.CHART_TYPE_BAR)

--- a/src/component/dataZoom.js
+++ b/src/component/dataZoom.js
@@ -299,7 +299,7 @@ define(function (require) {
                 serie = series[seriesIndex[i]];
                 this._originalData.series[seriesIndex[i]] = serie.data;
                 if (serie.data
-                    && this.getDataFromOption(serie.data[0]) instanceof Array
+                    && (serie.data.lengh ===0 || this.getDataFromOption(serie.data[0]) instanceof Array)
                     && (serie.type == ecConfig.CHART_TYPE_SCATTER
                         || serie.type == ecConfig.CHART_TYPE_LINE
                         || serie.type == ecConfig.CHART_TYPE_BAR)


### PR DESCRIPTION
当图表存在dataZoom时，图表series的data从有数据到无数据，图表绘制报错。