### PR TITLE
解决了一些bug等

### DIFF
--- a/src/chart/map.js
+++ b/src/chart/map.js
@@ -836,6 +836,7 @@ define(function (require) {
                 // 文字标签避免覆盖单独一个shape
                 textShape = {
                     zlevel : this.getZlevelBase(),
+                    _z : this.getZBase() + 1,
                     z : this.getZBase() + 1,
                     //hoverable: this._hoverable[mapType],
                     //clickable: this._clickable[mapType],
@@ -883,6 +884,7 @@ define(function (require) {
 
                 shape = {
                     zlevel : this.getZlevelBase(),
+                    _z : this.getZBase(),
                     z : this.getZBase(),
                     //hoverable: this._hoverable[mapType],
                     //clickable: this._clickable[mapType],
@@ -926,7 +928,9 @@ define(function (require) {
                      || data.selected === true
                 ) {
                     textShape.style = textShape.highlightStyle;
+                    textShape.z += 0.1;
                     shape.style = shape.highlightStyle;
+                    shape.z += 0.1;
                 }
 
                 textShape.clickable = shape.clickable =
@@ -1529,6 +1533,7 @@ define(function (require) {
                                 && this.shapeList[i]._mapType == mapType
                             ) {
                                 this.shapeList[i].style = this.shapeList[i]._style;
+                                this.shapeList[i].z = this.shapeList[i]._z;
                                 this.zr.modShape(this.shapeList[i].id);
                             }
                         }
@@ -1546,9 +1551,11 @@ define(function (require) {
                 ) {
                    if (this._selected[name]) {
                         this.shapeList[i].style = this.shapeList[i].highlightStyle;
+                        this.shapeList[i].z += 0.1;
                     }
                     else {
                         this.shapeList[i].style = this.shapeList[i]._style;
+                        this.shapeList[i].z = this.shapeList[i]._z;
                     }
                     this.zr.modShape(this.shapeList[i].id);
                 }

--- a/src/component/legend.js
+++ b/src/component/legend.js
@@ -71,6 +71,9 @@ define(function (require) {
         self._dispatchHoverLink = function(param) {
             return self.__dispatchHoverLink(param);
         };
+        self._dispatchMouseOut = function(param) {
+            return self.__dispatchMouseOut(param);
+        };
         
         this._colorIndex = 0;
         this._colorMap = {};
@@ -226,6 +229,7 @@ define(function (require) {
                 if (this.legendOption.selectedMode) {
                     itemShape.onclick = textShape.onclick = this._legendSelected;
                     itemShape.onmouseover =  textShape.onmouseover = this._dispatchHoverLink;
+                    itemShape.onmouseout =  textShape.onmouseout = this._dispatchMouseOut;
                     itemShape.hoverConnect = textShape.id;
                     textShape.hoverConnect = itemShape.id;
                 }
@@ -633,6 +637,21 @@ define(function (require) {
         __dispatchHoverLink : function(param) {
             this.messageCenter.dispatch(
                 ecConfig.EVENT.LEGEND_HOVERLINK,
+                param.event,
+                {
+                    target: param.target._name
+                },
+                this.myChart
+            );
+            return;
+        },
+        
+        /**
+         * 产生mouseout事件 
+         */
+        __dispatchMouseOut : function(param) {
+            this.messageCenter.dispatch(
+                ecConfig.EVENT.LEGEND_MOUSEOUT,
                 param.event,
                 {
                     target: param.target._name

--- a/src/config.js
+++ b/src/config.js
@@ -189,6 +189,7 @@ define(function() {
             DATA_RANGE_HOVERLINK: 'dataRangeHoverLink',
             LEGEND_SELECTED: 'legendSelected',
             LEGEND_HOVERLINK: 'legendHoverLink',
+            LEGEND_MOUSEOUT: 'legendMouseOut',
             MAP_SELECTED: 'mapSelected',
             PIE_SELECTED: 'pieSelected',
             MAGIC_TYPE_CHANGED: 'magicTypeChanged',

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -939,7 +939,7 @@ define(function (require) {
                 return this._setOption(option, notMerge);
             }
             else {
-                return this._setTimelineOption(option);
+                return this._setTimelineOption(option, notMerge);
             }
         },
 
@@ -1054,7 +1054,11 @@ define(function (require) {
          * timelineOption接口，配置图表实例任何可配置选项
          * @param {Object} option
          */
-        _setTimelineOption: function(option) {
+        _setTimelineOption: function(option, notMerge) {
+        	if (notMerge) {
+                this._setOption(option.options[0],true,false);
+            }
+        	
             this._timeline && this._timeline.dispose();
             var Timeline = require('./component/timeline');
             var timeline = new Timeline(

--- a/src/echarts.js
+++ b/src/echarts.js
@@ -1055,7 +1055,7 @@ define(function (require) {
          * @param {Object} option
          */
         _setTimelineOption: function(option, notMerge) {
-        	if (notMerge) {
+            if (notMerge) {
                 this._setOption(option.options[0],true,false);
             }
         	


### PR DESCRIPTION
#1803 
#2011 添加legend的mouseout事件，这样配合legend原有的hover事件，可实现自定义tooltip。

地图区域被选中后，高亮边界显示不全，示例：

http://echarts.baidu.com/doc/example/map2.html

option = {
    tooltip : {
        trigger: 'item',
        formatter: '{b}'
    },
    series : [
        {
            name: '中国',
            type: 'map',
            mapType: 'china',
            selectedMode : 'multiple',
            itemStyle:{
                normal:{
                    label:{show:true},
                    borderColor:'#FFF'
                },
                emphasis:{
                    label:{show:true},
                    borderColor:'#F00',
                    areaStyle: {
            	        color: false
            	    }}
            },
            data:[
                {name:'广东',selected:true},
                {name:'四川',selected:true}
            ]
        }
    ]
};

提高了选中状态下地图区域shape的z值，使其边界不被未选中的区域覆盖。

