### PR TITLE
fixed:DataZoom在mergeOption的时候没有overwrite，导致配置项设置boolan失效

### DIFF
--- a/src/component/dataZoom/DataZoomModel.js
+++ b/src/component/dataZoom/DataZoomModel.js
@@ -87,8 +87,8 @@ define(function(require) {
          * @override
          */
         mergeOption: function (newOption) {
-
-            newOption && zrUtil.merge(this.option, newOption);
+            //FIX #2591
+            newOption && zrUtil.merge(this.option, newOption, true);
 
             this.doInit(newOption, false);
         },


### PR DESCRIPTION
FIX https://github.com/ecomfe/echarts/issues/2591
看了半天代码，只改了一个参数，我表示不开心。