### PR TITLE
gauge pointerPath fix

### DIFF
--- a/src/chart/gauge/GaugeView.js
+++ b/src/chart/gauge/GaugeView.js
@@ -294,7 +294,13 @@ define(function (require) {
                 })
                 .update(function (newIdx, oldIdx) {
                     var pointer = oldData.getItemGraphicEl(oldIdx);
-
+                    if(isNaN(pointer.shape.angle)){
+                        pointer = new PointerPath({
+                            shape: {
+                                angle: startAngle
+                            }
+                        });
+                    }
                     graphic.updateProps(pointer, {
                         shape: {
                             angle: numberUtil.linearMap(data.get('value', newIdx), valueExtent, angleExtent, true)


### PR DESCRIPTION
当gauge设置一个未知值时，其指针消失，再次获得正确的值时，指针并未出现，添加角度为NAN时，重新初始化Pointer