### PR TITLE
Fix typo in ThemeRiverView.js

### DIFF
--- a/src/chart/themeRiver/ThemeRiverView.js
+++ b/src/chart/themeRiver/ThemeRiverView.js
@@ -130,7 +130,7 @@ define(function (require) {
                 }
 
                 var hoverItemStyleModel = itemModel.getModel('itemStyle.emphasis');
-                var itemStyleModel = itemModel.getModel('itemStyle.nomral');
+                var itemStyleModel = itemModel.getModel('itemStyle.normal');
                 var textStyleModel = labelModel.getModel('textStyle');
 
                 text.setStyle({


### PR DESCRIPTION
Fixed a typo inside ThemeRiverView.js which caused that users can not define itemStyle:{normal:{}} properties.. 