### PR TITLE
优化漏斗图排序问题： #1923 #4966

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ theme/thumb
 /lib
 todo
 **/*.log
+*.sublime-workspace
+*.sublime-project

--- a/src/chart/funnel/funnelLayout.js
+++ b/src/chart/funnel/funnelLayout.js
@@ -23,9 +23,15 @@ define(function (require) {
         for (var i = 0, len = data.count(); i < len; i++) {
             indices[i] = i;
         }
-        indices.sort(function (a, b) {
-            return isAscending ? valueArr[a] - valueArr[b] : valueArr[b] - valueArr[a];
-        });
+
+        // Add custom sortable function & none sortable opetion by "options.sort"
+        if (typeof sort === 'function') {
+            indices.sort(sort);
+        } else if (sort !== 'none') {
+            indices.sort(function (a, b) {
+                return isAscending ? valueArr[a] - valueArr[b] : valueArr[b] - valueArr[a];
+            });
+        }
         return indices;
     }
 


### PR DESCRIPTION
问题描述见这两个 Ticket: #1923 #4966  

为漏斗图的配置项`series[n].sort`增加了两个可选的排序类型（原来仅支持'ascending'和 'descending'）：

```javascript
{
	type: 'funnel',

	sort: 'none', // 新增加的选项值，表示渲染时不对数据进行排序，与传给 options.series[n].data 的顺序保持一致；
	sort: function(a,b){ return a-b; }, // 新增加的选项值，自定义 的排序方法；
	sort: 'ascending', // 原有
	sort: 'descending', // 默认值
	......
}
```