### PR TITLE
add Radar indicator can set different text color

### DIFF
--- a/src/coord/radar/RadarModel.js
+++ b/src/coord/radar/RadarModel.js
@@ -39,6 +39,11 @@ define(function (require) {
                 else if (indicatorOpt.min != null && indicatorOpt.min < 0 && !indicatorOpt.max) {
                     indicatorOpt.max = 0;
                 }
+                var iNameTextStyle = nameTextStyle
+                if(indicatorOpt.color != null){
+                    iNameTextStyle = zrUtil.clone(nameTextStyle)
+                    iNameTextStyle.color = indicatorOpt.color
+                }
                 // Use same configuration
                 indicatorOpt = zrUtil.merge(zrUtil.clone(indicatorOpt), {
                     boundaryGap: boundaryGap,
@@ -52,7 +57,7 @@ define(function (require) {
                     nameLocation: 'end',
                     nameGap: nameGap,
                     // min: 0,
-                    nameTextStyle: nameTextStyle,
+                    nameTextStyle: iNameTextStyle,
                     triggerEvent: triggerEvent
                 }, false);
                 if (!showName) {


### PR DESCRIPTION
Radar type indicator text allow config to different text color; by setting:

...
radar: [
    {
        indicator: [
            {text:'indicator1',color:'rgba(255, 2, 35, 1)',max:100},
            {text:'indicator2',color:'rgba(00, 176, 92, 1)',max:100},
        ],
    }
]
...

