### PR TITLE
use offsetWidth/Height to confine tooltip

### DIFF
--- a/src/component/tooltip/TooltipView.js
+++ b/src/component/tooltip/TooltipView.js
@@ -699,8 +699,8 @@ define(function (require) {
     }
 
     function refixTooltipPosition(x, y, el, viewWidth, viewHeight, gapH, gapV) {
-        var width = el.clientWidth;
-        var height = el.clientHeight;
+        var width = el.offsetWidth;
+        var height = el.offsetHeight;
 
         if (gapH != null) {
             if (x + width + gapH > viewWidth) {


### PR DESCRIPTION
The tooltip `confine` option currently uses `clientWidth` and `clientHeight` to ensure that the tooltip does not go outside the bounds of the chart. However, `clientWidth` and `clientHeight` do not include the size of the tooltip's border, which can cause the tooltip to go out of bounds. Using `offsetWidth` and `offsetHeight` fixes this issue.