### PR TITLE
数据视图（dataView）出现多余滚动条

### DIFF
--- a/src/component/toolbox/feature/DataView.js
+++ b/src/component/toolbox/feature/DataView.js
@@ -306,7 +306,7 @@ define(function (require) {
 
         var viewMain = document.createElement('div');
         var textarea = document.createElement('textarea');
-        viewMain.style.cssText = 'display:block;width:100%;overflow:auto;';
+        viewMain.style.cssText = 'display:block;width:100%;';
 
         var optionToContent = model.get('optionToContent');
         var contentToOption = model.get('contentToOption');


### PR DESCRIPTION
首先很高兴能用到echarts，在使用当中发现点击“数据视图（dataView）”按钮后，打开可编辑数据列表，在数据数量小于textarea高度时会出现多余滚动条，在数据数量超过textarea高度时候，会出现双滚动条现象。学习了下源码，现将div容器的overflow: auto;样式删除，观察了下这个样式好像并没有实际作用。希望能采用。谢谢。
复现例子（官方示例）：http://echarts.baidu.com/demo.html#dynamic-data
运行浏览器： 
+ chrome   版本 61.0.3163.13（正式版本）dev （64 位）
+ safari   版本 10.1.2 (12603.3.8)
