### PR TITLE
fix #6535 【BUG】src/util/clazz.js中的__DEV__没有做未定义判断

### DIFF
--- a/src/util/clazz.js
+++ b/src/util/clazz.js
@@ -67,7 +67,7 @@ define(function (require) {
         RootClass.$constructor = RootClass;
         RootClass.extend = function (proto) {
 
-            if (__DEV__) {
+            if (typeof __DEV__ !== 'undefined' && __DEV__) {
                 zrUtil.each(mandatoryMethods, function (method) {
                     if (!proto[method]) {
                         console.warn(
@@ -140,7 +140,7 @@ define(function (require) {
                 componentType = parseClassType(componentType);
 
                 if (!componentType.sub) {
-                    if (__DEV__) {
+                    if (typeof __DEV__ !== 'undefined' && __DEV__) {
                         if (storage[componentType.main]) {
                             console.warn(componentType.main + ' exists.');
                         }


### PR DESCRIPTION
在某些情况下(按需引入，在vue中使用extends方式，父模板引入echarts主体文件，各个图表子模板只需引入对应的图表类型文件而无需再次引入主体) 出现 __DEV__ is not defined

请查看，谢谢！

[https://github.com/ecomfe/echarts/issues/6535](https://github.com/ecomfe/echarts/issues/6535)