### PR TITLE
Fix bar overflow issues #4862 Bug fix

### DIFF
--- a/src/coord/axisHelper.js
+++ b/src/coord/axisHelper.js
@@ -5,10 +5,10 @@ import OrdinalScale from '../scale/Ordinal';
 import IntervalScale from '../scale/Interval';
 import Scale from '../scale/Scale';
 import * as numberUtil from '../util/number';
+import {calBarWidthAndOffset} from '../layout/barGrid';
 
 import '../scale/Time';
 import '../scale/Log';
-import '../layout/barGrid';
 
 /**
  * Get axis scale extent before niced.
@@ -115,11 +115,11 @@ export function getScaleExtent(scale, model) {
     // If bars are placed on a base axis of type time or interval account for axis boundary overflow and current axis is base axis
     var ecModel = model.getModel().ecModel;
     var numberBarPlots = ecModel.getSeriesByType("bar").length;
-    var isBaseAxis = model.ecModel._componentsMap._ec_series.map(function(x){ return x.getBaseAxis() === model.axis}).indexOf(true) !== -1; 
+    var isBaseAxis = model.ecModel.getSeries().map(function(x){ return x.getBaseAxis() === model.axis}).indexOf(true) !== -1; 
     if ((scaleType === 'time' || scaleType === 'interval') && numberBarPlots > 0 && isBaseAxis){
 
         // Adjust axis min and max to account for overflow
-        var adjustedScale = axisHelper.adjustScaleForOverflow(min, max, model);
+        var adjustedScale = adjustScaleForOverflow(min, max, model);
         min = adjustedScale.min;
         max = adjustedScale.max;
     }
@@ -127,15 +127,15 @@ export function getScaleExtent(scale, model) {
     return [min, max];
 }
 
-axisHelper.adjustScaleForOverflow = function (min, max, model) {
+export function adjustScaleForOverflow(min, max, model) {
     
     var ecModel = model.getModel().ecModel;
     // Get Axis Length
-    var axisExtent = model.axis._extent;
+    var axisExtent = model.axis.getExtent();
     var axisLength = axisExtent[1] - axisExtent[0]
 
     // Calculate placement of bars on axis
-    var barWidthAndOffset = barGrid.calBarWidthAndOffset(zrUtil.filter(
+    var barWidthAndOffset = calBarWidthAndOffset(zrUtil.filter(
         ecModel.getSeriesByType('bar'),
         function (seriesModel) {
             return !ecModel.isSeriesFiltered(seriesModel)

--- a/src/layout/barGrid.js
+++ b/src/layout/barGrid.js
@@ -318,5 +318,6 @@ function barLayoutGrid(seriesType, ecModel, api) {
 }
 
 barLayoutGrid.getLayoutOnAxis = getLayoutOnAxis;
+barLayoutGrid.calBarWidthAndOffset = calBarWidthAndOffset;
 
 export default barLayoutGrid;

--- a/src/layout/barGrid.js
+++ b/src/layout/barGrid.js
@@ -50,7 +50,7 @@ function getLayoutOnAxis(opt, api) {
     return result;
 }
 
-function calBarWidthAndOffset(barSeries, api) {
+export function calBarWidthAndOffset(barSeries, api) {
     var seriesInfoList = zrUtil.map(barSeries, function (seriesModel) {
         var data = seriesModel.getData();
         var cartesian = seriesModel.coordinateSystem;
@@ -318,6 +318,5 @@ function barLayoutGrid(seriesType, ecModel, api) {
 }
 
 barLayoutGrid.getLayoutOnAxis = getLayoutOnAxis;
-barLayoutGrid.calBarWidthAndOffset = calBarWidthAndOffset;
 
 export default barLayoutGrid;

--- a/test/bar-overflow-time-plot.html
+++ b/test/bar-overflow-time-plot.html
@@ -1,0 +1,159 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="esl.js"></script>
+        <script src="config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body>
+        <style>
+            h1 {
+                line-height: 60px;
+                height: 60px;
+                background: #146402;
+                text-align: center;
+                font-weight: bold;
+                color: #eee;
+                font-size: 14px;
+            }
+            .chart {
+                height: 600px;
+            }
+        </style>
+
+        <h1>
+            <input type="button" onclick="testHelper.setURLParam(['cn', 'en'], 'cn')" value="CN"/>
+            <input type="button" onclick="testHelper.setURLParam(['cn', 'en'], 'en')" value="EN"/>
+        </h1>
+
+        <div id="main" class="chart"></div>
+        <script>
+
+        require(
+            (testHelper.hasURLParam('en')
+                ? [
+                    'echarts',
+                    'echarts/lang/en',
+                ]
+                : [
+                    'echarts'
+                ]
+            ).concat(
+                [
+                    'echarts/chart/bar',
+                    'echarts/chart/line',
+                    'echarts/component/legend',
+                    'echarts/component/graphic',
+                    'echarts/component/grid',
+                    'echarts/component/tooltip',
+                    'echarts/component/brush',
+                    'echarts/component/toolbox',
+                    'echarts/component/title',
+                    'zrender/vml/vml'
+                ]
+            ),
+            function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main'));
+
+                var data1 = [[new Date(1498258800000), 10], [new Date(1498345200000), 15], [new Date(1498431600000), 15], [new Date(1498518000000), 15]];
+                var data2 = [[new Date(1498258800000), 15], [new Date(1498345200000), 20], [new Date(1498431600000), 15], [new Date(1498518000000), 15]];
+
+
+                var itemStyle = {
+                    normal: {
+                        barBorderRadius: 5,
+                        label: {
+                            show: true,
+                            position: 'outside'
+                        }
+                    },
+                    emphasis: {
+                        label: {
+                            position: 'outside'
+                        },
+                        barBorderColor: '#fff',
+                        barBorderWidth: 1,
+                        shadowBlur: 10,
+                        shadowOffsetX: 0,
+                        shadowOffsetY: 0,
+                        shadowColor: 'rgba(0,0,0,0.5)'
+                    }
+                };
+
+                chart.setOption({
+                    backgroundColor: '#eee',
+                    title: {
+                        text: '酒吧在时间轴上',
+                        padding: 20
+                    },
+                    legend: {
+                        left: 150,
+                        inactiveColor: '#abc',
+                        borderWidth: 1,
+                        selected: {
+                            // 'bar': false
+                        },
+                        // orient: 'vertical',
+                        // x: 'right',
+                        // y: 'bottom',
+                        align: 'left',
+                        tooltip: {
+                            show: true
+                        }
+
+                    },
+                    xAxis: {
+                        type: 'time',
+                        name: '横轴',
+                    },
+                    yAxis: {
+                        // axisLabel: {
+                        //     show: false
+                        // },
+                        axisTick: {
+                            show: false
+                        },
+                        splitArea: {
+                            show: false
+                        }
+                    },
+                    series: [{
+                        name: 'bar',
+                        type: 'bar',
+                        data: data1
+                    }, {
+                        name: 'bar2',
+                        type: 'bar',
+                        data: data2
+                    }]
+                });
+
+                chart.on('click', function (params) {
+                    console.log(params);
+                });
+
+                chart.on('legendselectchanged', function (params) {
+                    chart.setOption({
+                        // title: {
+                        // },
+                        graphic: [{
+                            type: 'circle',
+                            shape: {
+                                cx: 100,
+                                cy: 100,
+                                r: 20,
+                            }
+                        }]
+                    });
+                });
+
+                window.onresize = chart.resize;
+            }
+        );
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
I would like to propose the following pull request in reference to issue fixing #4862
针对问题 #4862， 我想提供一个合并请求。

**Summary**
**概述**

Rescale relevant base axis (of time and interval) to account for overflow of bars beyond chart.
伸缩相关的坐标轴（时间和区间）来解决长条溢出图表的问题

**Overview of changes**
**修改简述**

Two files edited.
共修改了两个文件

AxisHelper.js => has additional function to rescale axis
AxisHelper.js => 添加了伸缩坐标的函数

barGrid.js => export calBarWidthAndOffset
barGrid.js => 添加了calBarWidthAndOffset

**Proposed changes**
**所做的修改**

1. If axis is (time or interval) and has more then one bar and is a base axis
=> Recalculate axis min / max to account for bar overflow
如果坐标轴是时间或区间，并且有多个长条，并且次坐标为基本坐标，
那么伸缩坐标的最小最大值来解决长条溢出问题
2. Calculate physical length of current axis
计算现有坐标的物理长度
3. Calculate placement of bars on current axis
计算长条在坐标上的位置
4. Use current baseAxis to select bars on relevant axis
用当前的基本坐标来选择在相应坐标上的长条
=> If no bars on current axis return current max / min
如果，没有长条，那么返回当前的最大最小值
5. Rescale axis to account for overflow on each side of the chart
伸缩坐标来解决溢出问题
6. Return new axis min / max
返回新的最大最小值

**Test**
I have updated to include a test in file bar-overflow-time-plot.html

**Extra**
This issue also occurs with candlestick plotting on ordinal axis.
This could also be corrected with a similar function.
This can be seen in https://ecomfe.github.io/echarts-examples/public/editor.html?c=candlestick-sh
