### PR TITLE
Resolve build conflict

### DIFF
--- a/src/chart/bar.js
+++ b/src/chart/bar.js
@@ -1,6 +1,6 @@
 import * as echarts from '../echarts';
 import * as zrUtil from 'zrender/src/core/util';
-import barLayoutGrid from '../layout/barGrid';
+import {barLayoutGrid} from '../layout/barGrid';
 
 import '../coord/cartesian/Grid';
 import './bar/BarSeries';

--- a/src/chart/custom.js
+++ b/src/chart/custom.js
@@ -4,7 +4,7 @@ import * as zrUtil from 'zrender/src/core/util';
 import * as graphicUtil from '../util/graphic';
 import {findLabelValueDim} from './helper/labelHelper';
 import createListFromArray from './helper/createListFromArray';
-import barGrid from '../layout/barGrid';
+import {getLayoutOnAxis} from '../layout/barGrid';
 import DataDiffer from '../data/DataDiffer';
 
 import prepareCartesian2d from '../coord/cartesian/prepareCustom';
@@ -415,7 +415,7 @@ function makeRenderItem(customSeries, data, ecModel, api) {
     function barLayout(opt) {
         if (coordSys.getBaseAxis) {
             var baseAxis = coordSys.getBaseAxis();
-            return barGrid.getLayoutOnAxis(zrUtil.defaults({axis: baseAxis}, opt), api);
+            return getLayoutOnAxis(zrUtil.defaults({axis: baseAxis}, opt), api);
         }
     }
 

--- a/src/chart/pictorialBar.js
+++ b/src/chart/pictorialBar.js
@@ -5,7 +5,7 @@ import '../coord/cartesian/Grid';
 import './bar/PictorialBarSeries';
 import './bar/PictorialBarView';
 
-import barLayoutGrid from '../layout/barGrid';
+import {barLayoutGrid} from '../layout/barGrid';
 import visualSymbol from '../visual/symbol';
 
 // In case developer forget to include grid component

--- a/src/layout/barGrid.js
+++ b/src/layout/barGrid.js
@@ -21,7 +21,7 @@ function getAxisKey(axis) {
  * @param {number} [opt.barCategoryGap]
  * @return {Object} {width, offset, offsetCenter} If axis.type is not 'category', return undefined.
  */
-function getLayoutOnAxis(opt, api) {
+export function getLayoutOnAxis(opt, api) {
     var params = [];
     var baseAxis = opt.axis;
     var axisKey = 'axis0';
@@ -201,7 +201,7 @@ function doCalBarWidthAndOffset(seriesInfoList, api) {
  * @param {module:echarts/model/Global} ecModel
  * @param {module:echarts/ExtensionAPI} api
  */
-function barLayoutGrid(seriesType, ecModel, api) {
+export function barLayoutGrid(seriesType, ecModel, api) {
 
     var barWidthAndOffset = calBarWidthAndOffset(
         zrUtil.filter(
@@ -316,7 +316,3 @@ function barLayoutGrid(seriesType, ecModel, api) {
 
     }, this);
 }
-
-barLayoutGrid.getLayoutOnAxis = getLayoutOnAxis;
-
-export default barLayoutGrid;


### PR DESCRIPTION
Hi @pissang @100pah,

I have just noticed that the build script build.js throws an assertion error on barGrid as I am both exporting a function and doing a default export.

This occurs when I run npm install;

Specifically => node build/build.js --prepublish

Error
```
[transform]  /Users/conorokelly/Desktop/echarts/src/layout/barGrid.js ...
assert.js:41
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Forbiden that both export default and others.
```

I assumed the error was due to having both a default export and exporting a function. 

I have attempted to refactor the module barGrid and modules that where importing it. While the repo does build locally I was unable to get the unit tests to run so not sure if this solution is correct.

Conor