### PR TITLE
add resource echarts-leaflet in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ ECharts-GL is an extension pack of echarts, which providing 3D plots, globe visu
 + [leaflet-echarts](https://github.com/wandergis/leaflet-echarts3) by wandergis
 + [arcgis-echarts](https://github.com/wandergis/arcgis-echarts3) by wandergis
 
++ [echarts-leaflet](https://github.com/gnijuohz/echarts-leaflet) by gnijuohz
+
 #### AngularJS Binding
 
 + [angular-echarts](https://github.com/wangshijun/angular-echarts) by wangshijun


### PR DESCRIPTION
I noticed the leaflet extension in the readme hasn't been updated for a while and the source code is not actually available in that repo. Mine still is a work in progress but the basics are working.

Putting it here will help more people who needs it see it, and hopefully some will also help improve this extension.