### PR TITLE
containLabel should omit hidden labels

### DIFF
--- a/src/coord/cartesian/Grid.js
+++ b/src/coord/cartesian/Grid.js
@@ -42,7 +42,7 @@ function rotateTextRect(textRect, rotate) {
 
 function getLabelUnionRect(axis) {
     var axisModel = axis.model;
-    var labels = axisModel.getFormattedLabels();
+    var labels = axisModel.get('axisLabel.show') ? axisModel.getFormattedLabels() : [];
     var axisLabelModel = axisModel.getModel('axisLabel');
     var rect;
     var step = 1;


### PR DESCRIPTION
The calculation of a grid position with containLabel = true should not take into consideration the labels that are hidden by setting 'axisLabel.show' to false