### PR TITLE
Bar overflow issues #4862. Ensure absolute values are used when calculating overflow

### DIFF
--- a/src/coord/axisHelper.js
+++ b/src/coord/axisHelper.js
@@ -162,7 +162,9 @@ export function adjustScaleForOverflow(min, max, model) {
     zrUtil.each(barsOnCurrentAxis, function (item) {
         maxOverflow = Math.max(item.offset + item.width, maxOverflow);
     });
-    var totalOverFlow = Math.abs(minOverflow) + maxOverflow;
+    minOverflow = Math.abs(minOverflow);
+    maxOverflow = Math.abs(maxOverflow);
+    var totalOverFlow = minOverflow + maxOverflow;
 
     // Calulate required buffer based on old range and overflow
     var oldRange = max - min;

--- a/test/README.md
+++ b/test/README.md
@@ -21,7 +21,7 @@ Make sure `../dist/echarts.js` is the built based on current source files by:
 ```bash
 cd ../build
 npm install
-bash build.sh
+node build.js
 ```
 
 By default, we compare current version with last release version. To run the test, you should first download last release using:


### PR DESCRIPTION
Hi @pissang,

I noticed there with the latest release of ECharts 4.0.0 that the fix we had worked on earlier didn't seem to be working. 

It seems during the refactoring the min value was no longer being converted to an absolute value which meant the buffer was not being correctly set on each side.

I have updated src/coord/axisHelper.js to account for this.

I have also updated test/README.md to reference the new build script.

Please let me know if you want any more changes made!

Thanks,

Conor