### PR TITLE
Add new markline type `median`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+.idea
 
 node_modules
 

--- a/src/component/marker/MarkLineView.js
+++ b/src/component/marker/MarkLineView.js
@@ -7,12 +7,12 @@ import MarkerView from './MarkerView';
 
 var markLineTransform = function (seriesModel, coordSys, mlModel, item) {
     var data = seriesModel.getData();
-    // Special type markLine like 'min', 'max', 'average'
+    // Special type markLine like 'min', 'max', 'average', 'median'
     var mlType = item.type;
 
     if (!zrUtil.isArray(item)
         && (
-            mlType === 'min' || mlType === 'max' || mlType === 'average'
+            mlType === 'min' || mlType === 'max' || mlType === 'average' || mlType === 'median'
             // In case
             // data: [{
             //   yAxis: 10

--- a/src/component/marker/markerHelper.js
+++ b/src/component/marker/markerHelper.js
@@ -212,7 +212,11 @@ export function numCalculate(data, valueDataDim, type) {
         });
         return sum / count;
     }
+    else if (type === 'median') {
+        return data.getMedian(valueDataDim);
+    }
     else {
+        // max & min
         return data.getDataExtent(valueDataDim, true)[type === 'max' ? 1 : 0];
     }
 }

--- a/src/data/List.js
+++ b/src/data/List.js
@@ -861,6 +861,29 @@ listProto.getSum = function (dim /*, stack */) {
     return sum;
 };
 
+/**
+ * Get median of data in one dimension
+ * @param {string} dim
+ */
+listProto.getMedian = function (dim /*, stack */) {
+    var dimDataArray = [];
+    // map all data of one dimension
+    this.each(dim, function (val, idx) {
+        if (!isNaN(val)) {
+            dimDataArray.push(val);
+        }
+    });
+    // immutability & sort
+    var sortedDimDataArray = [].concat(dimDataArray).sort(function(a, b) {
+        return a - b;
+    });
+    var len = this.count();
+    // calculate median
+    return len === 0 ? 0 :
+        len % 2 === 1 ? sortedDimDataArray[(len - 1) / 2] :
+            (sortedDimDataArray[len / 2] + sortedDimDataArray[len / 2 - 1]) / 2;
+};
+
 // /**
 //  * Retreive the index with given value
 //  * @param {string} dim Concrete dimension.

--- a/test/scatter-markline.html
+++ b/test/scatter-markline.html
@@ -1,0 +1,127 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body, #main {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+        <div id="main"></div>
+        <script>
+
+            require([
+                'echarts'
+                // 'echarts/chart/scatter',
+                // 'echarts/component/legend',
+                // 'echarts/component/grid',
+                // 'echarts/component/tooltip',
+                // 'echarts/component/toolbox'
+            ], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main'));
+
+                var data1 = [];
+
+                var names = [
+                    'diamond, red, show inside label only on hover',
+                ];
+
+                var random = function (max) {
+                    return (Math.random() * max).toFixed(3);
+                }
+
+                for (var i = 0; i < 50; i++) {
+                    data1.push([random(5), random(5), random(2)]);
+                }
+
+                chart.setOption({
+                    aria: {
+                        show: true
+                    },
+                    legend: {
+                        data: names.slice()
+                    },
+                    toolbox: {
+                        left: 'left',
+                        feature: {
+                            dataView: {},
+                            saveAsImage: {},
+                            dataZoom: {}
+                        }
+                    },
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: {
+                            type: 'cross'
+                        }
+                    },
+                    xAxis: {
+                        type: 'value',
+                        splitLine: {
+                            show: false
+                        },
+                        min: 0,
+                        max: 15,
+                        splitNumber: 30
+                    },
+                    yAxis: {
+                        type: 'value',
+                        splitLine: {
+                            show: false
+                        }
+                    },
+                    series: [{
+                        name: names[0],
+                        type: 'scatter',
+                        label: {
+                            emphasis: {
+                                show: true
+                            }
+                        },
+                        symbol: 'diamond',
+                        symbolSize: function (val) {
+                            return val[2] * 40;
+                        },
+                        data: data1,
+                        markLine: {
+                            data: [
+                                {
+                                    name: '平均线',
+                                    type: 'average'
+                                },
+                                {
+                                    name: '最大值',
+                                    type: 'max'
+                                },
+                                {
+                                    name: '最小值',
+                                    type: 'min'
+                                },
+                                {
+                                    name: '中位数',
+                                    type: 'median'
+                                }
+                            ]
+                        }
+                    }],
+                    animationDelay: function (idx) {
+                        return idx * 20;
+                    },
+                    animationDelayUpdate: function (idx) {
+                        return idx * 20;
+                    }
+                });
+
+                chart.on('click', function (params) {
+                    console.log(params.data);
+                });
+            })
+
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
There are only 3 [markLine types](http://echarts.baidu.com/option.html#series-scatter.markLine.data.0.type):

 - max
 - min
 - average
 - ~median~

But there is another important type in data analysis, called median.

It can also be achieved by customize markLine option after calculate the median locally. But I think `median` should be a build-in markLine type for echarts.

----

Changelog:

1. add `median` markLine supported.
2. add the demo of markLine in scatter named `scatter-markline.html`.
3. update .gitignore.

----

Preview:

![image](https://user-images.githubusercontent.com/7856674/37136067-f5112466-22da-11e8-895b-6598953fe9f8.png)



